### PR TITLE
Change pdf sails hook to allow baseUrl separate configurability from redbox appUrl

### DIFF
--- a/typescript/api/services/PDFService.ts
+++ b/typescript/api/services/PDFService.ts
@@ -96,7 +96,11 @@ export module Services {
       });
       //TODO: get branding name from record
       let sourceUrlBase = options['sourceUrlBase'] || '/default/rdmp/record/view';
-      let currentURL = `${sails.config.appUrl}${sourceUrlBase}/${oid}`;
+      sails.log.verbose('PDFService::sourceUrlBase '+sourceUrlBase);
+      sails.log.verbose('PDFService::sails.config.pdfServiceAppUrlOverride '+sails.config.pdfServiceAppUrlOverride);
+      let pdfServiceAppUrlOverride = sails.config.pdfServiceAppUrlOverride;
+      let baseUrl = pdfServiceAppUrlOverride || sails.config.appUrl;
+      let currentURL = `${baseUrl}${sourceUrlBase}/${oid}`;
       this.processMap[currentURL] = true;
       sails.log.debug(`PDFService::Chromium loading page: ${currentURL}`);
       await page.goto(currentURL);

--- a/typescript/api/services/PDFService.ts
+++ b/typescript/api/services/PDFService.ts
@@ -97,9 +97,9 @@ export module Services {
       //TODO: get branding name from record
       let sourceUrlBase = options['sourceUrlBase'] || '/default/rdmp/record/view';
       sails.log.verbose('PDFService::sourceUrlBase '+sourceUrlBase);
-      sails.log.verbose('PDFService::sails.config.pdfServiceAppUrlOverride '+sails.config.pdfServiceAppUrlOverride);
-      let pdfServiceAppUrlOverride = sails.config.pdfServiceAppUrlOverride;
-      let baseUrl = pdfServiceAppUrlOverride || sails.config.appUrl;
+      sails.log.verbose('PDFService::sails.config.pdfgen.appUrlOverride '+sails.config.pdfgen.appUrlOverride);
+      let pdfgenAppUrlOverride = sails.config.pdfgen.appUrlOverride;
+      let baseUrl = pdfgenAppUrlOverride || sails.config.appUrl;
       let currentURL = `${baseUrl}${sourceUrlBase}/${oid}`;
       this.processMap[currentURL] = true;
       sails.log.debug(`PDFService::Chromium loading page: ${currentURL}`);


### PR DESCRIPTION
This change is mainly required to allow JCU specific case to work properly in local development where localhost is rbportal service however in test/prod environments a domain is used as appUrl therefore in test/prod environments the PDF Service is routed outside the container and then back in through nginx and redirected to /data baseUrl therefore to emulate this behavior in our local development the PDF Service has to be routed specifically to http://nginx/ service